### PR TITLE
Restructure files to eliminate circular dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS 
 
 setup(
     name='swiftbat_python',
-    version='0.1a2',
+    version='0.1a3',
     packages=['swiftbat'],
     url='',
     license='BSD-3-Clause',
@@ -26,5 +26,4 @@ setup(
     description='Routines for dealing with data from BAT on the Neil Gehrels Swift Observatory',
     entry_points={'console_scripts': ['swinfo=swiftbat.swinfo:main']},
     install_requires = ['beautifulsoup4', 'pyephem', 'astropy']
-
 )

--- a/swiftbat/__init__.py
+++ b/swiftbat/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-from .swinfo import *
+from .clockinfo import utcf
 from .swutil import *
+from .swinfo import *

--- a/swiftbat/clockinfo.py
+++ b/swiftbat/clockinfo.py
@@ -1,0 +1,143 @@
+from __future__ import division, print_function
+
+import os
+import glob
+import datetime
+
+"""
+From the FITS file:
+COMMENT
+COMMENT  Swift clock correction file
+COMMENT
+COMMENT  This file is used by tools that correct Swift times for the measured
+COMMENT  offset of the spacecraft clock based on fits to data provided by the
+COMMENT  Swift MOC. The columns contain polynomial coefficients for various time
+COMMENT  ranges and are used to compute the appropriate clock correction for any
+COMMENT  given mission elapsed time (after the first post-launch measurement).
+COMMENT  The technique is very similar to that used for RXTE fine timing.
+COMMENT
+COMMENT  In contrast to RXTE where these fine clock corrections have magnitudes
+COMMENT  measured in the tens of microseconds, the Swift corrections are much
+COMMENT  larger (~0.7 seconds at launch). At this writing (June 2005) the
+COMMENT  spacecraft clock still lags behind reference clocks on the ground but
+COMMENT  also runs fast.  The spacecraft clock is currently accelerating slowly.
+COMMENT
+COMMENT  Time is divided into intervals, expressed in spacecraft MET.
+COMMENT  Columns are: TSTART TSTOP TOFFSET C0 C1 C2 TYPE CHI_N DOF
+COMMENT  where
+COMMENT     TSTART and TSTOP are the interval boundaries (MET),
+COMMENT     TOFFSET is the clock offset (ie, TIMEZERO),
+COMMENT     MAXGAP is the largest gap with no data (-1 if unknown),
+COMMENT     CHI_N is the reduced chi-square value (-1 if unknown),
+COMMENT     DOF is the number of degrees of freedom,
+COMMENT     TYPE indicates the segment clock continuity (0=YES; 1=NO).
+COMMENT  (MAXGAP, CHI_N, DOF, and TYPE are retained for continuity with
+COMMENT  the file format used by RXTE but the values are currently all
+COMMENT  defaults and are not used in computing the actual clock offset.)
+COMMENT
+COMMENT  For a mission time of T, the correction in seconds is computed
+COMMENT  with the following:
+COMMENT     T1 = (T-TSTART)/86400
+COMMENT     TCORR = TOFFSET + (C0 + C1*T1 + C2*T1*T1)*1E-6
+"""
+
+
+theClockData = None
+
+
+
+caveat_time = 86400*90      # print a caveat if UTCF is more than 90 days stale
+
+
+class clockErrData:
+    # URL is never used on David Palmer's machine (updates handled by ...swift-trend/getit)
+    clockurl = "ftp://legacy.gsfc.nasa.gov/caldb/data/swift/mis/bcf/clock/"
+    # FIXME this should be derived from the dotswift params
+    clocklocalsearchpath = ['/Volumes/Data/Swift/swift-trend/clock',
+                            os.path.expanduser('~/.swift/swiftclock'),
+                            '/tmp/swiftclock']
+    clockfilepattern = 'swclockcor20041120v*.fits'
+
+    def __init__(self):
+        try:
+            self._clockfile = self.clockfile()
+            from astropy.io import fits
+            f = fits.open(self._clockfile)
+            # copies are needed to prevent pyfits from holding open a file handle for each item
+            self._tstart = f[1].data.field('TSTART').copy()
+            self._tstop = f[1].data.field('TSTOP').copy()
+            self._toffset = f[1].data.field('TOFFSET').copy()
+            self._c0 = f[1].data.field('C0').copy()
+            self._c1 = f[1].data.field('C1').copy()
+            self._c2 = f[1].data.field('C2').copy()
+            f.close()
+        except:
+            print("# Warning, no clock UTCF file")
+            self._clockfile = ""
+
+    def utcf(self, t, trow=None):  # Returns value in seconds to be added to MET to give correct UTCF
+        if not self._clockfile:
+            return 0.0, "No UTCF file"
+        if trow is None:
+            trow = t  # What time to use for picking out the row
+        caveats = ""
+        # Assume that the times are in order, and take the last one before t
+        row = [i for i in range(len(self._tstart)) if self._tstart[i] <= trow]
+        if len(row) == 0:
+            row = 0
+            caveats += "Time before first clock correction table entry"
+        else:
+            row = row[-1]
+            if self._tstop[row] + caveat_time < t:
+                caveats += "Time %.1f days after clock correction interval\n" % ((t - self._tstop[row]) / 86400)
+        ddays = (t - self._tstart[row]) / 86400.0
+        tcorr = self._toffset[row] + 1e-6 * (self._c0[row] + ddays * (self._c1[row] + ddays * self._c2[row]))
+        return -tcorr, caveats
+
+    def updateclockfiles(self, clockdir, ifolderthan_days=30):
+        try:
+            clockfile = glob.glob(os.path.join(clockdir, self.clockfilepattern))[-1]
+            age = datetime.datetime.utcnow() - datetime.datetime.fromtimestamp(os.path.getmtime(clockfile))
+            if age.total_seconds() < (86400 * ifolderthan_days):
+                return
+        except:
+            pass
+        # Requires wget.  If this is a problem, use ftplib.FTP
+        os.system(
+            "wget -q --directory-prefix=%s --no-host --no-clobber --cut-dirs=6 -r ftp://legacy.gsfc.nasa.gov/caldb/data/swift/mis/bcf/clock"
+            % clockdir)
+
+    def clockfile(self):
+        for clockdir in self.clocklocalsearchpath:
+            if os.path.exists(clockdir):
+                break
+        else:
+            try:
+                os.makedirs(clockdir)
+            except FileExistsError:
+                pass
+        try:
+            self.updateclockfiles(clockdir)
+        except Exception as e:
+            print("# ",e)
+        clockfile = clockfilelist = glob.glob(os.path.join(clockdir, self.clockfilepattern))[-1]
+        return clockfile
+
+def utcf(t, printCaveats=True, returnCaveats = False) :
+    global theClockData
+    if theClockData == None :
+        theClockData = clockErrData()
+    try :
+        uc = [theClockData.utcf(t_) for t_ in t]
+        # http://muffinresearch.co.uk/archives/2007/10/16/python-transposing-lists-with-map-and-zip/
+        u,c = map(None,*uc)
+        if printCaveats and any(c) :
+            print("\n".join(["**** " + c_ for c_ in c if c_]))
+    except TypeError :
+        u,c = theClockData.utcf(t)
+        if printCaveats and c :
+            print("**** " + c)
+    if returnCaveats :
+        return u,c
+    else :
+        return u

--- a/swiftbat/swutil.py
+++ b/swiftbat/swutil.py
@@ -37,7 +37,7 @@ if not execdir in map(os.path.abspath,sys.path) :
 
 import re
 import datetime
-from . import swinfo
+from .clockinfo import utcf
 import io
 
 # 2004-12-05T19:43:27
@@ -164,7 +164,7 @@ def string2datetime(s, nocomplaint = False, correct = False) :
         # None of the patterns match, try treating it as a straight number of seconds
         met = float(s)
         if correct :
-            utcf=swinfo.utcf(met, not nocomplaint, False)
+            utcf=utcf(met, not nocomplaint, False)
             met += utcf
         return met2datetime(met)
     except :
@@ -186,13 +186,13 @@ def timedelta2seconds(td) :
 
 def met2datetime(met, correct=False) :
     if correct :
-        met += swinfo.utcf(met, False, False)
+        met += utcf(met, False, False)
     return swiftepoch + datetime.timedelta(seconds = met )
     
 def datetime2met(dt, correct=False) :
     met = timedelta2seconds(dt - swiftepoch)
     if correct :
-        met -= swinfo.utcf(met, False, False)
+        met -= utcf(met, False, False)
     return met
 
 
@@ -212,7 +212,7 @@ def met2fitsString(met, milliseconds = False, correct = False, format=fitstimefo
 
 def met2mjd(met, correct = False) :
     if correct :
-        met += swinfo.utcf(met, False, False)
+        met += utcf(met, False, False)
     deltamjd = swiftepoch - mjdepoch
     mjd = met/86400.0 + deltamjd.days + deltamjd.seconds/86400.0
     return mjd


### PR DESCRIPTION
Moving the clock utilities into a separate file.  This eliminates some circular dependencies.

Also, allow the clock correction files to go into a ~/.swift/swiftclock directory (instead of reloading all of them when /tmp/ is emptied.)