### PR TITLE
Use https instead of ftp to get clock file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ except FileNotFoundError:
 
 setup(
     name='swiftbat',
-    version='0.1.2a3',
+    version='0.1.3',
     packages=['swiftbat'],
     package_data={'':['catalog', 'recent_bcttb.fits.gz']},
     url='https://github.com/lanl/swiftbat_python/',

--- a/swiftbat/__init__.py
+++ b/swiftbat/__init__.py
@@ -23,3 +23,4 @@ from .clockinfo import utcf
 from .swutil import *
 from .swinfo import *
 from .batcatalog import BATCatalog
+from . import generaldir

--- a/tests/testclock.py
+++ b/tests/testclock.py
@@ -18,6 +18,8 @@ class ClockTestCase(unittest.TestCase):
             utcf_returned = swiftbat.utcf(t)
             self.assertAlmostEqual(utcf_returned, utcf_expected, places=3)
 
+    def test_clock_download(self):
+        clockerrdata = clockErrData()
         with tempfile.TemporaryDirectory() as tempclockdir:
             clockerrdata.updateclockfiles(tempclockdir, ifolderthan_days=0)
             file = next(Path(tempclockdir).glob('swclock*.fits'))


### PR DESCRIPTION
Behind some proxies, (s)ftp(s) doesn't work very well.  So I have changed the clock file maintenance to use https instead.